### PR TITLE
feat: usersルーターに自信のアカウント情報を受け取るgetメソッドを追加

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -5,12 +5,14 @@ from sqlalchemy.orm import Session
 from schemas.user import UserCreate, UserRead
 from models.user import User
 from db.deps import get_db
-from utils.security import hash_password
+from core.security import hash_password
+from core.deps import get_current_user
 
-router = APIRouter()
+router = APIRouter(prefix = "/users",
+            tags = ["users"])
 
 # ユーザー登録用エンドポイント
-@router.post("/users", response_model = UserRead)
+@router.post("/", response_model = UserRead)
 def create_user(user: UserCreate, db: Session = Depends(get_db)):
 
     # Uniqueフィールド（email）の重複を確認
@@ -33,5 +35,6 @@ def create_user(user: UserCreate, db: Session = Depends(get_db)):
     db.refresh(db_user)                     # 保存後に、idなどが自動生成されるため再読み込み
     return db_user                          # 完了後、クライアントサイドに情報を返す
 
-
-
+@router.get("/me", response_model = UserRead)
+def get_me(current_user: User = Depends(get_current_user)):
+    return current_user


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- `/users/me` エンドポイントを追加

- 認証済みユーザー情報を取得

- ルーターにプレフィックスを設定

- `hash_password` のインポートを修正


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[クライアント] --> B{GET /users/me};
  B --> C[APIルーター];
  C -- "認証済みユーザー取得" --> D[現在のユーザー情報];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>users.py</strong><dd><code>ユーザー情報取得エンドポイントとルーター設定の更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/routers/users.py

<ul><li>認証済みユーザーの情報を取得する新しいGETエンドポイント <code>/me</code> を追加しました。<br> <li> <code>APIRouter</code> に <code>/users</code> のプレフィックスと <code>users</code> タグを設定しました。<br> <li> ユーザー登録エンドポイントのパスを <code>/users</code> から <code>/</code> に変更しました。<br> <li> <code>hash_password</code> のインポートパスを <code>utils.security</code> から <code>core.security</code> に更新しました。</ul>


</details>


  </td>
  <td><a href="https://github.com/rrr-bit00/time-aware-todo/pull/13/files#diff-79915502316113d1c673cab08fb68fc2dc1e7532ab1b4a71b29db681610a9940">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

